### PR TITLE
add mus-ignore-yosys-internal-netnames option

### DIFF
--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -158,7 +158,7 @@ namespace pono {
         }
       }
       Term t = unrollUntilBound(tc, k);
-      if (!options_.mus_include_yosys_internal_netnames_ && id->to_string().rfind('$', 0) == 0) {
+      if (!options_.mus_include_yosys_internal_netnames_ && isYosysInternalNetname(id)) {
         solver_->assert_formula(t);
       } else {
         transIdToConjunct.insert({id, t});
@@ -209,5 +209,11 @@ namespace pono {
     }
     return terms;
   }
+
+  bool Mus::isYosysInternalNetname(Term t)
+  {
+    return t->is_symbol() && t->to_string().rfind('$', 0) == 0;
+  }
+
 
 }  // namespace pono

--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -157,7 +157,12 @@ namespace pono {
           id = lhs;
         }
       }
-      transIdToConjunct.insert({id, unrollUntilBound(tc, k)});
+      Term t = unrollUntilBound(tc, k);
+      if (options_.mus_ignore_yosys_internal_netnames_ && id->to_string().rfind('$', 0) == 0) {
+        solver_->assert_formula(t);
+      } else {
+        transIdToConjunct.insert({id, t});
+      }
     }
 
     for (auto &ic: initConjuncts) {

--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -158,7 +158,7 @@ namespace pono {
         }
       }
       Term t = unrollUntilBound(tc, k);
-      if (options_.mus_ignore_yosys_internal_netnames_ && id->to_string().rfind('$', 0) == 0) {
+      if (!options_.mus_include_yosys_internal_netnames_ && id->to_string().rfind('$', 0) == 0) {
         solver_->assert_formula(t);
       } else {
         transIdToConjunct.insert({id, t});

--- a/engines/mus.h
+++ b/engines/mus.h
@@ -47,6 +47,7 @@ private:
   void assertControlEquality(const smt::Term& controlVar, const smt::Term& constraint);
   std::vector<smt::Term> musAsOrigTerms(MUS mus);
   void boolectorAliasCleanup(string fname);
+  static bool isYosysInternalNetname(smt::Term t);
 };  // class Mus
 
 }  // namespace pono

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -92,7 +92,7 @@ enum optionIndex
   KIND_ONE_TIME_BASE_CHECK,
   KIND_BOUND_STEP,
   MUS_ATOMIC_INIT,
-  MUS_IGNORE_YOSYS_INTERNAL_NETNAMES
+  MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES
 };
 
 struct Arg : public option::Arg
@@ -597,14 +597,14 @@ const option::Descriptor usage[] = {
   "constraints as a single MUS constraint. "
   "(default: false)"
   },
-{ MUS_IGNORE_YOSYS_INTERNAL_NETNAMES,
+{ MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES,
   0,
   "",
-  "--mus-ignore-yosys-internal-netnames",
+  "mus-include-yosys-internal-netnames",
   Arg::None,
-  "  --mus-ignore-yosys-internal-netnames \tDon't include '$'-prefixed symbols in"
-  "the MUS constraint set"
-  "(default: true)"
+  "  --mus-include-yosys-internal-netnames \tInclude '$'-prefixed symbols in "
+  "the MUS constraint set "
+  "(default: false)"
   },
 { 0, 0, 0, 0, 0, 0 },
 };
@@ -800,7 +800,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	    throw PonoException("--kind-bound-step must be greater than 0");
 	  break;
         case MUS_ATOMIC_INIT: mus_atomic_init_ = true; break;
-        case MUS_IGNORE_YOSYS_INTERNAL_NETNAMES: mus_ignore_yosys_internal_netnames_ = true; break;
+        case MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES: mus_include_yosys_internal_netnames_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -91,7 +91,8 @@ enum optionIndex
   KIND_NO_IND_CHECK_PROPERTY,
   KIND_ONE_TIME_BASE_CHECK,
   KIND_BOUND_STEP,
-  MUS_ATOMIC_INIT
+  MUS_ATOMIC_INIT,
+  MUS_IGNORE_YOSYS_INTERNAL_NETNAMES
 };
 
 struct Arg : public option::Arg
@@ -596,6 +597,15 @@ const option::Descriptor usage[] = {
   "constraints as a single MUS constraint. "
   "(default: false)"
   },
+{ MUS_IGNORE_YOSYS_INTERNAL_NETNAMES,
+  0,
+  "",
+  "--mus-ignore-yosys-internal-netnames",
+  Arg::None,
+  "  --mus-ignore-yosys-internal-netnames \tDon't include '$'-prefixed symbols in"
+  "the MUS constraint set"
+  "(default: true)"
+  },
 { 0, 0, 0, 0, 0, 0 },
 };
 /*********************************** end Option Handling setup
@@ -790,6 +800,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	    throw PonoException("--kind-bound-step must be greater than 0");
 	  break;
         case MUS_ATOMIC_INIT: mus_atomic_init_ = true; break;
+        case MUS_IGNORE_YOSYS_INTERNAL_NETNAMES: mus_ignore_yosys_internal_netnames_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -297,7 +297,9 @@ class PonoOptions
   unsigned kind_bound_step_;
   // MUS Engine: treat the conjunction of all init constraints as a single MUS constraint
   bool mus_atomic_init_;
-  // MUS Engine: Include '$'-prefixed symbols in the MUS constraint set
+  // MUS Engine: During synthesis, Yosys introduces internal ('$'-prefixed) identifiers
+  // that do not have a RTL-level correspondant. Include constraints corresponding to
+  // these internal identifiers in the MUS constraint set
   bool mus_include_yosys_internal_netnames_;
 
 private:

--- a/options/options.h
+++ b/options/options.h
@@ -153,7 +153,7 @@ class PonoOptions
         kind_one_time_base_check_(default_kind_one_time_base_check_),
         kind_bound_step_(default_kind_bound_step_),
         mus_atomic_init_(default_mus_atomic_init_),
-        mus_ignore_yosys_internal_netnames_(default_mus_ignore_yosys_internal_netnames_)
+        mus_include_yosys_internal_netnames_(default_mus_include_yosys_internal_netnames_)
 
   {
   }
@@ -297,8 +297,8 @@ class PonoOptions
   unsigned kind_bound_step_;
   // MUS Engine: treat the conjunction of all init constraints as a single MUS constraint
   bool mus_atomic_init_;
-  // MUS Engine: don't include '$'-prefixed symbols in the MUS constraint set
-  bool mus_ignore_yosys_internal_netnames_;
+  // MUS Engine: Include '$'-prefixed symbols in the MUS constraint set
+  bool mus_include_yosys_internal_netnames_;
 
 private:
   // Default options
@@ -368,7 +368,7 @@ private:
   static const bool default_kind_one_time_base_check_ = false;
   static const unsigned default_kind_bound_step_ = 1;
   static const bool default_mus_atomic_init_ = false;
-  static const bool default_mus_ignore_yosys_internal_netnames_ = true;
+  static const bool default_mus_include_yosys_internal_netnames_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -152,7 +152,9 @@ class PonoOptions
         kind_no_ind_check_property_(default_kind_no_ind_check_property_),
         kind_one_time_base_check_(default_kind_one_time_base_check_),
         kind_bound_step_(default_kind_bound_step_),
-        mus_atomic_init_(default_mus_atomic_init_)
+        mus_atomic_init_(default_mus_atomic_init_),
+        mus_ignore_yosys_internal_netnames_(default_mus_ignore_yosys_internal_netnames_)
+
   {
   }
 
@@ -295,6 +297,8 @@ class PonoOptions
   unsigned kind_bound_step_;
   // MUS Engine: treat the conjunction of all init constraints as a single MUS constraint
   bool mus_atomic_init_;
+  // MUS Engine: don't include '$'-prefixed symbols in the MUS constraint set
+  bool mus_ignore_yosys_internal_netnames_;
 
 private:
   // Default options
@@ -364,6 +368,7 @@ private:
   static const bool default_kind_one_time_base_check_ = false;
   static const unsigned default_kind_bound_step_ = 1;
   static const bool default_mus_atomic_init_ = false;
+  static const bool default_mus_ignore_yosys_internal_netnames_ = true;
 };
 
 // Useful functions for printing etc...


### PR DESCRIPTION
Add an option for the MUS engine to not include constraints associated with yosys internal netnames (those with '$'-prefixed names) in the MUS constraint set. 