### PR TITLE
add pono flag to dump MUST smt2 query

### DIFF
--- a/engines/mus.h
+++ b/engines/mus.h
@@ -36,6 +36,7 @@ private:
     {SPEC, "SPEC"}
   };
   smt::TermVec controlVars;
+  smt::TermVec assertions;
   void assert_formula(smt::Term t, smt::TermTranslator tt);
   smt::UnorderedTermSet extractTopLevelConjuncts(smt::Term conjunction);
   smt::Term unrollUntilBound(smt::Term t, int k);

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -92,7 +92,8 @@ enum optionIndex
   KIND_ONE_TIME_BASE_CHECK,
   KIND_BOUND_STEP,
   MUS_ATOMIC_INIT,
-  MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES
+  MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES,
+  MUS_DUMP_SMT2
 };
 
 struct Arg : public option::Arg
@@ -606,6 +607,14 @@ const option::Descriptor usage[] = {
   "the MUS constraint set "
   "(default: false)"
   },
+  { MUS_DUMP_SMT2,
+  0,
+  "",
+  "mus-dump-smt2",
+  Arg::None,
+  "  --mus-dump-smt2 \toutput the smt2 query being sent to MUST to a file "
+  "(default: false)"
+  },
 { 0, 0, 0, 0, 0, 0 },
 };
 /*********************************** end Option Handling setup
@@ -801,6 +810,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  break;
         case MUS_ATOMIC_INIT: mus_atomic_init_ = true; break;
         case MUS_INCLUDE_YOSYS_INTERNAL_NETNAMES: mus_include_yosys_internal_netnames_ = true; break;
+        case MUS_DUMP_SMT2: mus_dump_smt2_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -153,8 +153,8 @@ class PonoOptions
         kind_one_time_base_check_(default_kind_one_time_base_check_),
         kind_bound_step_(default_kind_bound_step_),
         mus_atomic_init_(default_mus_atomic_init_),
-        mus_include_yosys_internal_netnames_(default_mus_include_yosys_internal_netnames_)
-
+        mus_include_yosys_internal_netnames_(default_mus_include_yosys_internal_netnames_),
+        mus_dump_smt2_(default_mus_dump_smt2)
   {
   }
 
@@ -301,6 +301,8 @@ class PonoOptions
   // that do not have a RTL-level correspondant. Include constraints corresponding to
   // these internal identifiers in the MUS constraint set
   bool mus_include_yosys_internal_netnames_;
+  // MUS Engine: output the smt2 query being sent to MUST to a file
+  bool mus_dump_smt2_;
 
 private:
   // Default options
@@ -371,6 +373,7 @@ private:
   static const unsigned default_kind_bound_step_ = 1;
   static const bool default_mus_atomic_init_ = false;
   static const bool default_mus_include_yosys_internal_netnames_ = false;
+  static const bool default_mus_dump_smt2 = false;
 };
 
 // Useful functions for printing etc...


### PR DESCRIPTION
Added the `--mus-dump-smt2` option to pono which will output the smt2 query being sent to MUST to a file. 