### PR TITLE
MUSes for self-composed programs 

### DIFF
--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -65,7 +65,7 @@ namespace pono {
     if (type == INVAR) {
       s = std::to_string(t->hash());
     }
-    return makeControlVar(constraintTypeToStr[type] + "_" + s);
+    return makeControlVar(type, s);
   }
 
   Term Mus::makeControlVar(ConstraintType type, const string s)

--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -178,9 +178,9 @@ namespace pono {
        * supplied regular expression.
        */
       std::multimap<string, Term> mm;
+      regex r(std::regex("(.*)" + options_.mus_combine_suffix_));
       for (auto & [id, tc] : unordered_map(transIdToConjunct)) {
         smatch m;
-        regex r(std::regex("(.*)" + options_.mus_combine_suffix_));
         if (regex_search(id, m, r)) {
           mm.insert({m[1], tc});
           transIdToConjunct.erase(id);

--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -68,9 +68,9 @@ namespace pono {
     return makeControlVar(type, s);
   }
 
-  Term Mus::makeControlVar(ConstraintType type, const string s)
+  Term Mus::makeControlVar(ConstraintType type, const string suffix)
   {
-    return makeControlVar(constraintTypeToStr[type] + "_" + s);
+    return makeControlVar(constraintTypeToStr[type] + "_" + suffix);
   }
 
   void Mus::assertControlEquality(const Term& controlVar, const Term& constraint)

--- a/engines/mus.cpp
+++ b/engines/mus.cpp
@@ -254,6 +254,9 @@ namespace pono {
         terms.push_back(controlVars[i]);
       }
     }
+    std::sort(terms.begin(), terms.end(), [](const Term & a, const Term & b) {
+      return a->to_string() < b->to_string();
+    });
     return terms;
   }
 

--- a/engines/mus.h
+++ b/engines/mus.h
@@ -45,6 +45,7 @@ private:
   smt::Term makeControlVar(string id);
   smt::Term makeControlVar(ConstraintType type);
   smt::Term makeControlVar(ConstraintType type, smt::Term t);
+  smt::Term makeControlVar(ConstraintType type, string s);
   void assertControlEquality(const smt::Term& controlVar, const smt::Term& constraint);
   std::vector<smt::Term> musAsOrigTerms(MUS mus);
   void boolectorAliasCleanup(string fname);

--- a/engines/mus.h
+++ b/engines/mus.h
@@ -37,8 +37,9 @@ private:
   };
   smt::TermVec controlVars;
   smt::TermVec assertions;
-  void assert_formula(smt::Term t, smt::TermTranslator tt);
   smt::UnorderedTermSet extractTopLevelConjuncts(smt::Term conjunction);
+  void musAssert(smt::Term controlVar, smt::Term constraint);
+  void contextualAssert(smt::Term constraint);
   smt::Term unrollUntilBound(smt::Term t, int k);
   smt::Term unrollOrigTerm(smt::Term t, int k);
   smt::Term makeConjunction(smt::TermVec ts);
@@ -46,7 +47,6 @@ private:
   smt::Term makeControlVar(ConstraintType type);
   smt::Term makeControlVar(ConstraintType type, smt::Term t);
   smt::Term makeControlVar(ConstraintType type, string s);
-  void assertControlEquality(const smt::Term& controlVar, const smt::Term& constraint);
   std::vector<smt::Term> musAsOrigTerms(MUS mus);
   void boolectorAliasCleanup(string fname);
   static bool isYosysInternalNetname(smt::Term t);

--- a/options/options.h
+++ b/options/options.h
@@ -154,6 +154,7 @@ class PonoOptions
         kind_bound_step_(default_kind_bound_step_),
         mus_atomic_init_(default_mus_atomic_init_),
         mus_include_yosys_internal_netnames_(default_mus_include_yosys_internal_netnames_),
+        mus_combine_suffix_(default_mus_combine_suffix_),
         mus_dump_smt2_(default_mus_dump_smt2)
   {
   }
@@ -301,6 +302,12 @@ class PonoOptions
   // that do not have a RTL-level correspondant. Include constraints corresponding to
   // these internal identifiers in the MUS constraint set
   bool mus_include_yosys_internal_netnames_;
+  // MUS Engine: Combine contraints corresponding to terms that are identical up
+  // to a suffix matching the supplied regular expression. When reasoning over
+  // an input model that encodes a hyperproeprty over a self-composed program,
+  // this enables combining all instances (copies) of a source-level compononent
+  // together as an atomic constraint.
+  std::string mus_combine_suffix_;
   // MUS Engine: output the smt2 query being sent to MUST to a file
   bool mus_dump_smt2_;
 
@@ -373,6 +380,7 @@ private:
   static const unsigned default_kind_bound_step_ = 1;
   static const bool default_mus_atomic_init_ = false;
   static const bool default_mus_include_yosys_internal_netnames_ = false;
+  static const std::string default_mus_combine_suffix_;
   static const bool default_mus_dump_smt2 = false;
 };
 


### PR DESCRIPTION
When using the pono MUS engine to reason over a model encoding a self-composed program (i.e. explicitly duplicated with copies differentiated by e.g. '_0'/_1' suffixes), each element of each copy will be treated as an atomic constraint. We'd like to be able to reason about MUSes of the source-level (non-self-composed) program. 

This MR adds the `mus-combine-suffix` option to to the MUS engine. This option expects a regex as an argument which it uses to determine elements of the self-composed program that correspond to the same source-level element. Constraints corresponding to symbols that are identical up to a suffix matching the supplied regex will be conjoined to a single constraint.

[channel_buffer_mus.smv](https://gitlab-ext.galois.com/quiip/quiip-models/-/tree/789841a53fbca3a1f916adc90a8ec29f30778d91/test/smv/non_interference/channel_buffer_mus) encodes a self-composed program using '_0'/'_1' suffixes to differentiate the copies. Invoking the pono MUS engine on this model with `--mus-combine-suffix _[0-1]` yields MUSes composed of constraints corresponding the the source-level program:

```
MUS #1
  ...
  TRANS_a1
  TRANS_a2
  TRANS_aIn
  TRANS_aOut
  TRANS_pc
  ...
...
```